### PR TITLE
#8_Streamline_lodash_imports

### DIFF
--- a/client/js/api/responses.js
+++ b/client/js/api/responses.js
@@ -1,4 +1,5 @@
-import { find, isEmpty } from 'lodash';
+import find 	from 'lodash/find';
+import isEmpty 	from 'lodash/isEmpty';
 import { store } from '../reducers';
 import { roomActions } from '../actionCreators';
 import { getStorageItem, setStorageItem } from '../utilities/helperMethods';

--- a/client/js/api/responses.js
+++ b/client/js/api/responses.js
@@ -1,8 +1,7 @@
-import find 	from 'lodash/find';
-import isEmpty 	from 'lodash/isEmpty';
 import { store } from '../reducers';
 import { roomActions } from '../actionCreators';
 import { getStorageItem, setStorageItem } from '../utilities/helperMethods';
+import { find, isEmpty } from '../utilities/lodash';
 
 function identifyForFullstory(room, participant) {
 	if (!window.FS) return;

--- a/client/js/components/JoinRoom.js
+++ b/client/js/components/JoinRoom.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import isEmpty 	from 'lodash/isEmpty';
-import keys 	from 'lodash/keys';
-import map 		from 'lodash/map';
 import { apiRequests } from '../api';
 import { CARDS } from '../utilities/constants';
+import { isEmpty, keys, map } from '../utilities/lodash';
 import { getQueryParam } from '../utilities/helperMethods';
 
 const mapStateToProps = ({ requests }) => {

--- a/client/js/components/JoinRoom.js
+++ b/client/js/components/JoinRoom.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEmpty, keys, map } from 'lodash';
+import isEmpty 	from 'lodash/isEmpty';
+import keys 	from 'lodash/keys';
+import map 		from 'lodash/map';
 import { apiRequests } from '../api';
 import { CARDS } from '../utilities/constants';
 import { getQueryParam } from '../utilities/helperMethods';

--- a/client/js/components/PokerRoom.js
+++ b/client/js/components/PokerRoom.js
@@ -1,12 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import find 	from 'lodash/find';
-import isEmpty 	from 'lodash/isEmpty';
-import isEqual 	from 'lodash/isEqual';
-import map 		from 'lodash/map';
 import { apiRequests } from '../api';
 import { itemActions, modalActions, participantActions } from '../actionCreators';
 import { CARDS } from '../utilities/constants';
+import { find, isEmpty, isEqual, map } from '../utilities/lodash';
 import { getStorageItem } from '../utilities/helperMethods';
 import { ShareLinkModal } from './modals';
 

--- a/client/js/components/PokerRoom.js
+++ b/client/js/components/PokerRoom.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { find, isEmpty, isEqual, map } from 'lodash';
+import find 	from 'lodash/find';
+import isEmpty 	from 'lodash/isEmpty';
+import isEqual 	from 'lodash/isEqual';
+import map 		from 'lodash/map';
 import { apiRequests } from '../api';
 import { itemActions, modalActions, participantActions } from '../actionCreators';
 import { CARDS } from '../utilities/constants';

--- a/client/js/components/Router.js
+++ b/client/js/components/Router.js
@@ -13,10 +13,13 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEmpty, isEqual } from 'lodash';
+import isEmpty 	from 'lodash/isEmpty';
+import isEqual 	from 'lodash/isEqual';
+
 import { getStorageItem } from '../utilities/helperMethods';
 import { REQUEST_STATES } from '../utilities/constants';
 import { apiRequests } from '../api';
+
 import PokerRoom from './PokerRoom';
 import JoinRoom from './JoinRoom';
 

--- a/client/js/components/Router.js
+++ b/client/js/components/Router.js
@@ -13,13 +13,10 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import isEmpty 	from 'lodash/isEmpty';
-import isEqual 	from 'lodash/isEqual';
-
-import { getStorageItem } from '../utilities/helperMethods';
-import { REQUEST_STATES } from '../utilities/constants';
+import { REQUEST_STATES } 	from '../utilities/constants';
+import { getStorageItem } 	from '../utilities/helperMethods';
+import { isEmpty, isEqual } from '../utilities/lodash';
 import { apiRequests } from '../api';
-
 import PokerRoom from './PokerRoom';
 import JoinRoom from './JoinRoom';
 

--- a/client/js/components/modals/ShareLinkModal.js
+++ b/client/js/components/modals/ShareLinkModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
+import isEqual 	from 'lodash/isEqual';
 import { modalActions } from '../../actionCreators';
 import ModalWrapper from './ModalWrapper';
 

--- a/client/js/components/modals/ShareLinkModal.js
+++ b/client/js/components/modals/ShareLinkModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import isEqual 	from 'lodash/isEqual';
+import { isEqual } from '../../utilities/lodash';
 import { modalActions } from '../../actionCreators';
 import ModalWrapper from './ModalWrapper';
 

--- a/client/js/reducers/modals.js
+++ b/client/js/reducers/modals.js
@@ -1,4 +1,4 @@
-import { assign } from 'lodash';
+import assign from 'lodash/assign';
 
 const init = {
 	shareLinkModalIsOpen: false

--- a/client/js/reducers/modals.js
+++ b/client/js/reducers/modals.js
@@ -1,4 +1,4 @@
-import assign from 'lodash/assign';
+import { assign } from '../utilities/lodash';
 
 const init = {
 	shareLinkModalIsOpen: false

--- a/client/js/reducers/participant.js
+++ b/client/js/reducers/participant.js
@@ -1,5 +1,4 @@
-import assign from 'lodash/assign';
-import isEqual from 'lodash/isEqual';
+import { assign, isEqual } from '../utilities/lodash';
 
 const init = {};
 

--- a/client/js/reducers/participant.js
+++ b/client/js/reducers/participant.js
@@ -1,4 +1,5 @@
-import { assign, isEqual } from 'lodash';
+import assign from 'lodash/assign';
+import isEqual from 'lodash/isEqual';
 
 const init = {};
 

--- a/client/js/reducers/requests.js
+++ b/client/js/reducers/requests.js
@@ -1,7 +1,5 @@
-import assign 	from 'lodash/assign';
-import forEach 	from 'lodash/forEach';
-import keys 	from 'lodash/keys';
 import { API_ENDPOINTS, REQUEST_STATES } from '../utilities/constants';
+import { assign, forEach, keys } from '../utilities/lodash';
 
 let init = {};
 

--- a/client/js/reducers/requests.js
+++ b/client/js/reducers/requests.js
@@ -1,4 +1,6 @@
-import { assign, forEach, keys } from 'lodash';
+import assign 	from 'lodash/assign';
+import forEach 	from 'lodash/forEach';
+import keys 	from 'lodash/keys';
 import { API_ENDPOINTS, REQUEST_STATES } from '../utilities/constants';
 
 let init = {};

--- a/client/js/reducers/room.js
+++ b/client/js/reducers/room.js
@@ -1,4 +1,8 @@
-import { assign, filter, isEmpty, isEqual, map } from 'lodash';
+import assign 	from 'lodash/assign';
+import filter 	from 'lodash/filter';
+import isEmpty 	from 'lodash/isEmpty';
+import isEqual 	from 'lodash/isEqual';
+import map 		from 'lodash/map';
 
 const init = {
 	id: null,

--- a/client/js/reducers/room.js
+++ b/client/js/reducers/room.js
@@ -1,8 +1,4 @@
-import assign 	from 'lodash/assign';
-import filter 	from 'lodash/filter';
-import isEmpty 	from 'lodash/isEmpty';
-import isEqual 	from 'lodash/isEqual';
-import map 		from 'lodash/map';
+import { assign, filter, isEmpty, isEqual, map } from '../utilities/lodash';
 
 const init = {
 	id: null,

--- a/client/js/utilities/helperMethods.js
+++ b/client/js/utilities/helperMethods.js
@@ -1,8 +1,5 @@
-import forEach 	 from 'lodash/forEach';
-import filter 	 from 'lodash/filter';
-import findIndex from 'lodash/findIndex';
-import isEmpty 	 from 'lodash/isEmpty';
 import { API_ENDPOINTS } from './constants';
+import { forEach, filter, findIndex, isEmpty } from './lodash';
 
 /**
  * Route Parser

--- a/client/js/utilities/helperMethods.js
+++ b/client/js/utilities/helperMethods.js
@@ -1,4 +1,7 @@
-import { forEach, filter, findIndex, isEmpty } from 'lodash';
+import forEach 	 from 'lodash/forEach';
+import filter 	 from 'lodash/filter';
+import findIndex from 'lodash/findIndex';
+import isEmpty 	 from 'lodash/isEmpty';
 import { API_ENDPOINTS } from './constants';
 
 /**

--- a/client/js/utilities/lodash.js
+++ b/client/js/utilities/lodash.js
@@ -1,0 +1,7 @@
+export { default as assign } from 'lodash/assign';
+export { default as find } from 'lodash/find';
+export { default as forEach } from 'lodash/forEach';
+export { default as isEmpty } from 'lodash/isEmpty';
+export { default as isEqual } from 'lodash/isEqual';
+export { default as keys } from 'lodash/keys';
+export { default as map } from 'lodash/map';

--- a/client/js/wireframes/ReactClassComponent.js
+++ b/client/js/wireframes/ReactClassComponent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
+import isEqual 	from 'lodash/isEqual';
 import { actionCreator } from '../actions';
 
 const mapStateToProps = ({ reducerA, reducerB }) => {

--- a/client/js/wireframes/ReactClassComponent.js
+++ b/client/js/wireframes/ReactClassComponent.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import isEqual 	from 'lodash/isEqual';
 import { actionCreator } from '../actions';
+import { isEqual } from '../utilities/lodash';
 
 const mapStateToProps = ({ reducerA, reducerB }) => {
 	return {

--- a/client/js/wireframes/reducer.js
+++ b/client/js/wireframes/reducer.js
@@ -1,4 +1,4 @@
-import { assign } from 'lodash';
+import assign 	from 'lodash/assign';
 
 const init = {};
 

--- a/client/js/wireframes/reducer.js
+++ b/client/js/wireframes/reducer.js
@@ -1,4 +1,4 @@
-import assign 	from 'lodash/assign';
+import { assign } from '../utilities/lodash';
 
 const init = {};
 

--- a/cypress/integration/front-end_regression_spec.js
+++ b/cypress/integration/front-end_regression_spec.js
@@ -84,7 +84,7 @@ describe('PokerRoom page loads and works', () => {
 			for (let i=0;i<3;i++) {
 				cy.get('input[type="text"].item-name').type(data.itemName+i);
 				cy.get('div.btn.create-item').click().then(() => {
-					cy.get('div.participant-panel__header').contains('Current item: ' + data.itemName+i);
+					cy.get('div.participant-panel__header').contains(data.itemName+i);
 					forEach(cardValues, cardValue => {
 						cy.get('div.poker-card').contains(cardValue).should('not.have.class', 'disabled');
 					})


### PR DESCRIPTION
Resolves #8 

#### Summary of Implementation
- Changed over to importing individual lodash utility methods rather than entire library
- Grouped individual imports into utility file to avoid repeat imports and allow for spread operator imports

#### Check List
- [x] Regression tests passing